### PR TITLE
Allows tk-hiero-openinshotgun to be used by the tk-nuke engine.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -2,7 +2,7 @@
 configuration:
 
 # the engines that this app can operate in:
-supported_engines: [tk-hiero]
+supported_engines: [tk-hiero, tk-nuke]
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
Allows the app to run from the tk-nuke engine.
