### PR TITLE
#37359 Allows 'Open in Shotgun' to work on items with effects

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,9 +59,12 @@ class HieroOpenInShotgun(Application):
         """
         Look up shot in shotgun from selection
         """
-        # grab the current selection from the view that triggered the event
-        selection = self.engine.get_menu_selection()
-        
+
+        # grab the current selection from the view that triggered the event.
+        # Exclude effects from the list of selected items
+        selection = [s for s in self.engine.get_menu_selection()
+            if not isinstance(s, hiero.core.EffectTrackItem)]
+
         if len(selection) != 1:
             raise TankError("Please select a single Shot!")
         


### PR DESCRIPTION
This is a tiny change that filters out `EffectTrackItems` from selection to allow the **Open in Shotgun** menu action to work on items with an attached effect.
