### PR TITLE
SG-43662 Remove Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -32,7 +32,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -11,3 +11,4 @@ requires_shotgun_fields:
 display_name: "Open In Flow Production Tracking"
 description: "App that adds a context menu to open track items as Shots in
              Flow Production Tracking"
+minimum_python_version: "3.9"


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`
- Bump pre-commit hooks

## Test plan

- [ ] Pre-commit passes cleanly
- [ ] No Python 3.7 references remain (verified by automated check script)